### PR TITLE
Fix command not found error by updating docker-compose to docker compose

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build docker
-        run: docker-compose build app
+        run: docker compose build app
       - name: Update CIDRs
-        run: docker-compose run --rm app
+        run: docker compose run --rm app
       - name: Push updates
         run: |
           if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
# Summary
Changed docker-compose to docker compose to fix the command not found error.

# Changes
Updated the docker-compose commands to docker compose in the GitHub Actions workflow file.

# Background
The docker-compose command was causing a command not found error in the GitHub Actions workflow. This is because docker-compose has been integrated into the docker CLI as docker compose. This change ensures that the workflow runs correctly.
