### PR TITLE
Updated Azure URL to the new one

### DIFF
--- a/generate-csv.sh
+++ b/generate-csv.sh
@@ -19,7 +19,7 @@ cidrs_gcp=$(wget -qO- https://www.gstatic.com/ipranges/cloud.json | grep -o "$CI
 echo -n "GCP CIDRs: "
 echo "$cidrs_gcp" | wc -l
 
-cidrs_azure=$(wget -qO- $(wget -qO- -U Mozilla https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519 | grep -Eo 'https://download.microsoft.com/download/\S+?\.json' | head -n 1) | grep -o "$CIDR_REGEX" | sort -V )
+cidrs_azure=$(wget -qO- $(wget -qO- -U Mozilla https://www.microsoft.com/en-us/download/details.aspx?id=56519 | grep -Eo 'https://download.microsoft.com/download/\S+?\.json' | head -n 1) | grep -o "$CIDR_REGEX" | sort -V )
 echo -n "Azure CIDRs: "
 echo "$cidrs_azure" | wc -l
 


### PR DESCRIPTION
This pull request includes a change to the `generate-csv.sh` script to update the URL for downloading Azure CIDR ranges. The change corrects the URL for downloading the JSON file containing Azure CIDR ranges.

* [`generate-csv.sh`](diffhunk://#diff-d29cbcf77eb55aa1361b7bfbd3c9b1e0f819a8ddc214a49e089e5d629a19a59aL22-R22): Updated the URL for downloading the JSON file with Azure CIDR ranges from `https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519` to `https://www.microsoft.com/en-us/download/details.aspx?id=56519`.